### PR TITLE
PM-116[PropertyAPI][Task]: fixed signedUrl throwing error for empty path

### DIFF
--- a/server/src/services/document.services.ts
+++ b/server/src/services/document.services.ts
@@ -105,6 +105,8 @@ export const DocumentService = {
 	async getPrivateDocs({ label, id }: { label: PrivateDocs; id: string }) {
 		const privateDocs = await DocumentRepository.getPrivateDocuments(label, id);
 		const paths = privateDocs.map((doc) => doc.path);
+		if (paths.length === 0) return [];
+
 		const signedURLs = await createSignedURLs(paths);
 
 		return signedURLs.map((url) => url.signedUrl);


### PR DESCRIPTION
Related to #95 